### PR TITLE
[DW-4230] Use image hash rather than latest tag

### DIFF
--- a/terraform/deploy/app/frontendservice.tf
+++ b/terraform/deploy/app/frontendservice.tf
@@ -12,6 +12,8 @@ module "ecs-fargate-task-definition" {
   container_memory_reservation = var.container_memory_reservation
   common_tags                  = local.common_tags
   role_arn                     = "arn:aws:iam::${local.account[local.environment]}:role/${var.assume_role}"
+  management_role_arn          = "arn:aws:iam::${local.account[local.management_account[local.environment]]}:role/${var.assume_role}"
+  repository_name              = var.ecr_repository_name
   account                      = lookup(local.account, local.environment)
   log_configuration = {
     secretOptions = []

--- a/terraform/deploy/app/variables.tf
+++ b/terraform/deploy/app/variables.tf
@@ -203,6 +203,12 @@ variable "proxy_configuration" {
   default     = []
 }
 
+variable "ecr_repository_name" {
+  type        = string
+  description = "Name of the ECR repository where container image is stored"
+  default     = "aws-analytical-env/analytical-frontend-service"
+}
+
 # ---------------------------------------------------------------------------------------------------------------------
 # AWS ECS SERVICE
 # ---------------------------------------------------------------------------------------------------------------------

--- a/terraform/modules/fargate-task-definition/ecs.tf
+++ b/terraform/modules/fargate-task-definition/ecs.tf
@@ -1,9 +1,16 @@
+data "aws_ecr_image" "ecr_image" {
+  provider = aws.management
+
+  repository_name = var.repository_name
+  image_tag       = "latest"
+}
+
 module "container_definition" {
   source  = "cloudposse/ecs-container-definition/aws"
   version = "0.21.0"
 
   container_name               = var.container_name
-  container_image              = var.container_image
+  container_image              = "${var.container_image}@${data.aws_ecr_image.ecr_image.image_digest}"
   container_memory             = var.container_memory
   container_memory_reservation = var.container_memory_reservation
   port_mappings                = local.port_mappings

--- a/terraform/modules/fargate-task-definition/iam.tf
+++ b/terraform/modules/fargate-task-definition/iam.tf
@@ -1,5 +1,6 @@
 data "aws_iam_policy_document" "ecs-tasks" {
   statement {
+    sid = "AllowAssumeRole"
     actions = [
       "sts:AssumeRole",
     ]

--- a/terraform/modules/fargate-task-definition/provider.tf
+++ b/terraform/modules/fargate-task-definition/provider.tf
@@ -1,0 +1,8 @@
+provider "aws" {
+  alias  = "management"
+  region = "eu-west-2"
+
+  assume_role {
+    role_arn = var.management_role_arn
+  }
+}

--- a/terraform/modules/fargate-task-definition/variables.tf
+++ b/terraform/modules/fargate-task-definition/variables.tf
@@ -244,3 +244,13 @@ variable "common_tags" {
   type        = map(string)
   description = "(Required) common tags to apply to aws resources"
 }
+
+variable "management_role_arn" {
+  type        = string
+  description = "(Required) The role to assume when accessing resources in management"
+}
+
+variable "repository_name" {
+  type        = string
+  description = "name of the ECR repository for the container imager"
+}


### PR DESCRIPTION
When we make changes to the container image, we want the ability to force a redeploy of the ECS cluster. By updating the task definition to use an image SHA rather than tag, any changes will cause a redeploy. 