### PR TITLE
DW-4755 Add fix for Microsoft Edge being incompatible with everything

### DIFF
--- a/src/components/auth/Authenticator.js
+++ b/src/components/auth/Authenticator.js
@@ -3,7 +3,7 @@ import {AmplifyAuthenticator} from "@aws-amplify/ui-react";
 import {AuthContext} from "../../utils/Auth";
 import {Hub} from "aws-amplify";
 import CustomAuthWrapper from "./CustomAuthWrapper";
-import {isBrowserEnv} from "../../utils/appConfig";
+import {isBrowserEnv, isMicrosoftBrowser} from "../../utils/appConfig";
 import AdfsSignin from "./AdfsSignIn";
 
 const Authenticator = ({children}) => {
@@ -27,7 +27,7 @@ const Authenticator = ({children}) => {
     }, [authContext]);
 
 
-    if (isBrowserEnv() && 'customElements' in window) // check if WebComponents is supported (for Edge/IE)
+    if (isBrowserEnv() && !isMicrosoftBrowser())
         return (
             <AmplifyAuthenticator>
                 <CustomAuthWrapper headerText='Analytical environment sign in'/>

--- a/src/utils/appConfig.js
+++ b/src/utils/appConfig.js
@@ -30,3 +30,7 @@ export function getConfigOrDefault(key, defaultValue) {
 export function isBrowserEnv() {
     return typeof window !== "undefined" && !process.title.endsWith("node")
 }
+
+export function isMicrosoftBrowser() {
+    return !!(document.documentMode || /Edge/.test(navigator.userAgent));
+}


### PR DESCRIPTION
Implement a fix for Microsoft doing what Microsoft does. Its implementation of `window.sessionStorage` is different from all other browsers in that it will clear all data stored if the page navigates to a website in a different "security zone" (see https://docs.microsoft.com/en-us/azure/active-directory/develop/msal-js-known-issues-ie-edge-browsers). This causes the amplify flow to fail as the PCKE key stored in the sessionStorage is needed on the final request to `oauth2/tokens` endpoint for the request to succeed. 

This could have been easily fixed if AWS respected the custom storage object passed in the [configuration](https://docs.amplify.aws/lib/auth/start/q/platform/js#re-use-existing-authentication-resource) for all storage needs, but it does not, the oAuth storage is hardcoded to session storage (see [oAuth.ts](https://github.com/aws-amplify/amplify-js/blob/a047ce73abe98c3bf82e888c3afb4d2f911805f3/packages/auth/src/OAuth/OAuth.ts#L16) and [oAuthStorage](https://github.com/aws-amplify/amplify-js/blob/a047ce73abe98c3bf82e888c3afb4d2f911805f3/packages/auth/src/OAuth/oauthStorage.ts)).

Therefore, this fix employs overriding the `urlOpener` config property to save the needed PCKE key to localStorage before navigating away to the oauth2 authorize flow, and then intercepts the `fetch` call to the `oauth2/tokens` endpoint to add the key to the request body. 